### PR TITLE
add alpha disclaimer and hide controls

### DIFF
--- a/packages/slides/css/theme/ionic-vue.css
+++ b/packages/slides/css/theme/ionic-vue.css
@@ -62,7 +62,6 @@ body {
 
 .reveal .progress {
   background-color: rgba(0,0,0,0.1);
-  height: 10px;
 }
 
 .reveal .progress span {

--- a/packages/slides/index.html
+++ b/packages/slides/index.html
@@ -316,6 +316,7 @@
 
         <section class="interstitial" data-background-color="#4fc08d">
           <h1>@ionic/vue 🎉</h1>
+          <code class="fragment">(alpha)</code>
           <aside class="notes">
             <li>Today I am happy to announce that we have released @ionic/vue in alpha.
             <li>When I say alpha I mean 0.0.1. All components are provided but we

--- a/packages/slides/index.html
+++ b/packages/slides/index.html
@@ -412,7 +412,7 @@ new Vue({
       // https://github.com/hakimel/reveal.js#configuration
       Reveal.initialize({
         backgroundTransition: 'none',
-        controls: true,
+        controls: false,
         progress: true,
         history: true,
         center: true,


### PR DESCRIPTION
Don't want to spring changes on you too late, but this is pretty minor. It adds an alpha disclaimer as a fragment to the announcement slide...

<img width="1014" alt="screen shot 2018-11-16 at 11 21 25 am" src="https://user-images.githubusercontent.com/2547860/48633673-c5a11c80-e991-11e8-83a3-151bfc49e885.png">

...and hides the controls. I thought they might be kind of distracting and you probably don't need them.

<img width="1392" alt="screen shot 2018-11-16 at 11 21 51 am" src="https://user-images.githubusercontent.com/2547860/48633738-e8333580-e991-11e8-8441-898b410e275a.png">

